### PR TITLE
Allows X and Y labels to be shown independently.

### DIFF
--- a/achartengine/src/org/achartengine/chart/AbstractChart.java
+++ b/achartengine/src/org/achartengine/chart/AbstractChart.java
@@ -427,7 +427,7 @@ public abstract class AbstractChart implements Serializable {
     if (renderer.isShowLegend() && legendSize == 0) {
       legendSize = defaultHeight;
     }
-    if (!renderer.isShowLegend() && renderer.isShowLabels()) {
+    if (!renderer.isShowLegend() && renderer.isShowXLabels()) {
       legendSize = (int) (renderer.getLabelsTextSize() * 4 / 3 + extraHeight);
     }
     return legendSize;

--- a/achartengine/src/org/achartengine/chart/TimeChart.java
+++ b/achartengine/src/org/achartengine/chart/TimeChart.java
@@ -93,14 +93,14 @@ public class TimeChart extends LineChart {
       Paint paint, int left, int top, int bottom, double xPixelsPerUnit, double minX, double maxX) {
     int length = xLabels.size();
     if (length > 0) {
-      boolean showLabels = mRenderer.isShowLabels();
+      boolean showXLabels = mRenderer.isShowXLabels();
       boolean showGridY = mRenderer.isShowGridY();
       boolean showTickMarks = mRenderer.isShowTickMarks();
       DateFormat format = getDateFormat(xLabels.get(0), xLabels.get(length - 1));
       for (int i = 0; i < length; i++) {
         long label = Math.round(xLabels.get(i));
         float xLabel = (float) (left + xPixelsPerUnit * (label - minX));
-        if (showLabels) {
+        if (showXLabels) {
           paint.setColor(mRenderer.getXLabelsColor());
           if (showTickMarks) {
             canvas.drawLine(xLabel, bottom, xLabel, bottom + mRenderer.getLabelsTextSize() / 3,

--- a/achartengine/src/org/achartengine/chart/XYChart.java
+++ b/achartengine/src/org/achartengine/chart/XYChart.java
@@ -706,13 +706,13 @@ public abstract class XYChart extends AbstractChart {
   protected void drawXLabels(List<Double> xLabels, Double[] xTextLabelLocations, Canvas canvas,
       Paint paint, int left, int top, int bottom, double xPixelsPerUnit, double minX, double maxX) {
     int length = xLabels.size();
-    boolean showLabels = mRenderer.isShowLabels();
+    boolean showXLabels = mRenderer.isShowXLabels();
     boolean showGridY = mRenderer.isShowGridY();
     boolean showTickMarks = mRenderer.isShowTickMarks();
     for (int i = 0; i < length; i++) {
       double label = xLabels.get(i);
       float xLabel = (float) (left + xPixelsPerUnit * (label - minX));
-      if (showLabels) {
+      if (showXLabels) {
         paint.setColor(mRenderer.getXLabelsColor());
         if (showTickMarks) {
           canvas
@@ -727,13 +727,13 @@ public abstract class XYChart extends AbstractChart {
         canvas.drawLine(xLabel, bottom, xLabel, top, paint);
       }
     }
-    drawXTextLabels(xTextLabelLocations, canvas, paint, showLabels, left, top, bottom,
+    drawXTextLabels(xTextLabelLocations, canvas, paint, showXLabels, left, top, bottom,
         xPixelsPerUnit, minX, maxX);
   }
 
   /**
    * The graphical representation of the labels on the Y axis.
-   * 
+   *
    * @param allYLabels the Y labels values
    * @param canvas the canvas to paint to
    * @param paint the paint to be used for drawing
@@ -748,7 +748,7 @@ public abstract class XYChart extends AbstractChart {
       int maxScaleNumber, int left, int right, int bottom, double[] yPixelsPerUnit, double[] minY) {
     Orientation or = mRenderer.getOrientation();
     boolean showGridX = mRenderer.isShowGridX();
-    boolean showLabels = mRenderer.isShowLabels();
+    boolean showYLabels = mRenderer.isShowYLabels();
     boolean showTickMarks = mRenderer.isShowTickMarks();
     for (int i = 0; i < maxScaleNumber; i++) {
       paint.setTextAlign(mRenderer.getYLabelsAlign(i));
@@ -760,7 +760,7 @@ public abstract class XYChart extends AbstractChart {
         boolean textLabel = mRenderer.getYTextLabel(label, i) != null;
         float yLabel = (float) (bottom - yPixelsPerUnit[i] * (label - minY[i]));
         if (or == Orientation.HORIZONTAL) {
-          if (showLabels && !textLabel) {
+          if (showYLabels && !textLabel) {
             paint.setColor(mRenderer.getYLabelsColor(i));
             if (axisAlign == Align.LEFT) {
               if (showTickMarks) {
@@ -785,7 +785,7 @@ public abstract class XYChart extends AbstractChart {
             canvas.drawLine(left, yLabel, right, yLabel, paint);
           }
         } else if (or == Orientation.VERTICAL) {
-          if (showLabels && !textLabel) {
+          if (showYLabels && !textLabel) {
             paint.setColor(mRenderer.getYLabelsColor(i));
             if (showTickMarks) {
               canvas.drawLine(right - getLabelLinePos(axisAlign), yLabel, right, yLabel, paint);

--- a/achartengine/src/org/achartengine/renderer/DefaultRenderer.java
+++ b/achartengine/src/org/achartengine/renderer/DefaultRenderer.java
@@ -55,8 +55,10 @@ public class DefaultRenderer implements Serializable {
   private int mYAxisColor = TEXT_COLOR;
   /** The X axis color. */
   private int mXAxisColor = TEXT_COLOR;
-  /** If the labels are visible. */
-  private boolean mShowLabels = true;
+  /** If the X labels are visible. */
+  private boolean mShowXLabels = true;
+  /** If the Y labels are visible. */
+  private boolean mShowYLabels = true;
   /** If the tick marks are visible. */
   private boolean mShowTickMarks = true;
   /** The labels color. */
@@ -363,21 +365,51 @@ public class DefaultRenderer implements Serializable {
   }
 
   /**
-   * Returns if the labels should be visible.
-   * 
+   * Returns if either of the labels should be visible.
+   *
    * @return the visibility flag for the labels
    */
   public boolean isShowLabels() {
-    return mShowLabels;
+    return mShowXLabels || mShowYLabels;
+  }
+
+  /**
+   * Returns if the X labels should be visible.
+   *
+   * @return the visibility flag for the X labels
+   */
+  public boolean isShowXLabels() {
+    return mShowXLabels;
+  }
+
+  /**
+   * Returns if the Y labels should be visible.
+   *
+   * @return the visibility flag for the Y labels
+   */
+  public boolean isShowYLabels() {
+    return mShowYLabels;
   }
 
   /**
    * Sets if the labels should be visible.
-   * 
+   *
+   * @param showXLabels the visibility flag for the X labels
+   * @param showYLabels the visibility flag for the Y labels
+   */
+  public void setShowLabels(boolean showXLabels, boolean showYLabels) {
+    mShowXLabels = showXLabels;
+    mShowYLabels = showYLabels;
+  }
+
+  /**
+   * Sets if the labels should be visible.
+   *
    * @param showLabels the visibility flag for the labels
    */
   public void setShowLabels(boolean showLabels) {
-    mShowLabels = showLabels;
+    mShowXLabels = showLabels;
+    mShowYLabels = showLabels;
   }
 
   /**


### PR DESCRIPTION
Allows X and Y labels to be shown independently. When no X labels are shown, decreases the legend size appropriately.