### PR TITLE
Mark Paint objects as transient to fix Parcelable IOException in Demo.

### DIFF
--- a/achartengine/src/org/achartengine/chart/TimeChart.java
+++ b/achartengine/src/org/achartengine/chart/TimeChart.java
@@ -41,7 +41,7 @@ public class TimeChart extends LineChart {
   /** The starting point for labels. */
   private Double mStartPoint;
   /** The paint to be used when drawing the grid lines. */
-  private Paint mGridPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+  private transient Paint mGridPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
   TimeChart() {
   }

--- a/achartengine/src/org/achartengine/chart/XYChart.java
+++ b/achartengine/src/org/achartengine/chart/XYChart.java
@@ -67,7 +67,7 @@ public abstract class XYChart extends AbstractChart {
   /** The calculated range. */
   private final Map<Integer, double[]> mCalcRange = new HashMap<Integer, double[]>();
   /** The paint to be used when drawing the grid lines. */
-  private Paint mGridPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+  private transient Paint mGridPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
   /**
    * The clickable areas for all points. The array index is the series index,


### PR DESCRIPTION
I didn't actually try this with the demo, but this doesn't seem to cause any regression and supposidly ought to fix the IOException bug #490 